### PR TITLE
In Comment Section of Book, User Can Click on Email of the Commentator …

### DIFF
--- a/app/views/books/_comments.html.erb
+++ b/app/views/books/_comments.html.erb
@@ -4,7 +4,7 @@
   <br>
   <div>
     <small>Submitted <%= time_ago_in_words(comments.created_at) %> ago</small>
-    <small><%= comments.user.email %></small>
+    <small><%= mail_to comments.user.email, "#{comments.user.email}" %></small>
     <p class="red_reply_text" ng-click="showForm(<%= comments.id %>)" ng-if="showComment !== <%= comments.id %>">reply</p>
   </div>
   <div ng-if="showComment === <%= comments.id %>" class="alert alert-warning alert-dismissible fade in" role="alert" >


### PR DESCRIPTION
…and be directed to email
-In the Books Show Page, a User can now click on the email of one of the commentators and will automatically open a draft email in their default email service.